### PR TITLE
Render HTML in connectedCallback instead of constructor

### DIFF
--- a/index.md
+++ b/index.md
@@ -76,8 +76,12 @@ Lets take the __buy button__ as an example. Team Product includes the button sim
     class BlueBuy extends HTMLElement {
       constructor() {
         super();
+      }
+      
+      connectedCallback() {
         this.innerHTML = `<button type="button">buy for 66,00 €</button>`;
       }
+      
       disconnectedCallback() { ... }
     }
     window.customElements.define('blue-buy', BlueBuy);
@@ -119,7 +123,9 @@ To support this the Custom Element can implement the `attributeChangedCallback` 
         return ['sku'];
       }
       constructor() {
-        super();
+        super();        
+      }
+      connectedCallback() {
         this.render();
       }
       render() {


### PR DESCRIPTION
It is recommended to do HTML rendering inside the connectedCallback instead of
the constructor. Putting the update to `innerHTML` inside the constructor
sometimes results in a "Uncaught DOMException: Failed to construct
'CustomElement': The result must not have attributes" e.g. when the script that
creates the custom element is dynamically reloaded.

Relevant StackOverflow page: https://stackoverflow.com/a/43837330